### PR TITLE
Fix Too Many Query 50001 for orgs with more than 5k Users

### DIFF
--- a/force-app/main/default/classes/PSLab_PermissionAnalysisController.cls
+++ b/force-app/main/default/classes/PSLab_PermissionAnalysisController.cls
@@ -12,6 +12,11 @@ public with sharing class PSLab_PermissionAnalysisController{
     }
 
     @AuraEnabled(Cacheable = true)
+    public static List<Object> searchUsers(String searchTerm) {
+        return PSLab_PermissionAnalysisHelper.searchUsers(searchTerm);
+    }
+
+    @AuraEnabled(Cacheable = true)
     public static PSLab_HierarchyNode getPermissionSetHierarchy() {
         return PSLab_PermissionAnalysisHelper.getPermissionSetHierarchy();
     }

--- a/force-app/main/default/classes/PSLab_PermissionAnalysisHelper.cls
+++ b/force-app/main/default/classes/PSLab_PermissionAnalysisHelper.cls
@@ -241,6 +241,38 @@ public without sharing class PSLab_PermissionAnalysisHelper {
     }
 
     /**
+     * @description   Searches for active users by name or username.
+     * @author        Oumaima Arbani | 2025-09-04
+     * @param         searchTerm The string to search for.
+     * @return        List<Object> A list of maps representing matching users.
+     **/
+    public static List<Object> searchUsers(String searchTerm) {
+        String likeQuery = '%' + String.escapeSingleQuotes(searchTerm) + '%';
+        Integer queryLimit = 20; // Limit results to a reasonable number for UI display
+
+        List<User> usersList = [
+                SELECT Id, Name, Username
+                FROM User
+                WHERE (Name LIKE :likeQuery OR Username LIKE :likeQuery) AND IsActive = TRUE
+                WITH SYSTEM_MODE
+                ORDER BY Name ASC
+                LIMIT :queryLimit
+        ];
+
+        List<Object> users = new List<Object>();
+        for (User user : usersList) {
+            users.add(
+                    new Map<String, Object>{
+                            'Id' => user.Id,
+                            'label' => user.Name + ' (' + user.Username + ')',
+                            'value' => user.Id
+                    }
+            );
+        }
+        return users;
+    }
+
+    /**
      * @description   Retrieves all Users in the org and formats them for a UI dropdown.
      * @author        Oumaima Arbani | 2025-08-22
      * @return        List<Object> A list of maps, each representing a User.

--- a/force-app/main/default/lwc/psLabDetectorFilter/psLabDetectorFilter.html
+++ b/force-app/main/default/lwc/psLabDetectorFilter/psLabDetectorFilter.html
@@ -18,6 +18,8 @@
                                          is-multi-select = {isMultiSelect}
                                          required = {isRequired}
                                          onchange={handlePermissionsAPINameChange}
+                                         onsearch={handleUserSearch}
+                                         is-server-search={isUserSearchMode}
                                          value={permissionSetsOrPSGApiNames}></c-ps-lab-multi-select-combo-box>
       </div>
 

--- a/force-app/main/default/lwc/psLabMultiSelectComboBox/psLabMultiSelectComboBox.js
+++ b/force-app/main/default/lwc/psLabMultiSelectComboBox/psLabMultiSelectComboBox.js
@@ -21,6 +21,7 @@ export default class PsLabMultiSelectComboBox extends LightningElement {
   @api name = '';
   @api required = false;
   @api isMultiSelect;
+  @api isServerSearch = false;
 
   get options() {
     return this._options;
@@ -110,6 +111,12 @@ export default class PsLabMultiSelectComboBox extends LightningElement {
   handleInput(event) {
     this.searchTerm = event.target.value;
     this.showDropdown = true;
+
+    if (this.isServerSearch) {
+      this.dispatchEvent(new CustomEvent('search', {
+        detail: { value: this.searchTerm }
+      }));
+    }
   }
 
   openDropdown() {


### PR DESCRIPTION
### 🔗 Linked Issue or Feature
Closes: #_ISSUE_NUMBER_

### 📝 PR Summary

---

### 🧐 What is the current behavior?

-  Toast error if user search type was selected and the Org has more than 5K users

### ✨ What is the new behavior?

- Load the first 5k users, then use the search term to fetch the first 20 users that matches it

---

### 🧪 How to Test
1.
2.
3.

### 📸 Screenshots / GIFs

---

## 🧑‍💻 Developer Checklist

### 1. Code & Standards
- [x] My code follows the style guidelines of this project.
- [x] Metadata is organized correctly under `force-app/main/default`.
- [x] Code is formatted with Prettier.
- [x] Apex PMD (Code Analyzer) reports 0 violations.
- [x] I have removed all commented-out code.
- [x] I have updated the documentation accordingly.

### 2. Testing & Coverage
- [x] All new and existing Apex test classes pass.
- [x] Every class has at least a code coverage of **≥ 75%**.
- [x] All tests use `System.runAs()` to simulate a non-admin user context.
- [x] Any changes involving Permission Set Groups include a call to `Test.calculatePermissionSetGroup()` in the test setup.